### PR TITLE
Allow passing arguments through and require Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
-module.exports = cb => new Promise(resolve => {
-	resolve(cb());
+module.exports = (cb, ...args) => new Promise(resolve => {
+	resolve(cb(...args));
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6"
 	},
 	"scripts": {
 		"test": "xo && ava"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # p-try [![Build Status](https://travis-ci.org/sindresorhus/p-try.svg?branch=master)](https://travis-ci.org/sindresorhus/p-try)
 
-> [`Promise.try()`](https://github.com/tc39/proposal-promise-try) [ponyfill](https://ponyfill.com) - Starts a promise chain
+> Starts a promise chain
 
 [How is it useful?](http://cryto.net/~joepie91/blog/2016/05/11/what-is-promise-try-and-why-does-it-matter/)
 
@@ -32,6 +32,8 @@ pTry(() => {
 ### pTry(fn, ...args)
 
 Returns a `Promise` resolved with the value of calling `fn(...args)`. If the function throws an error, the returned `Promise` will be rejected with that error.
+
+Support for passing arguments on to the function is provided in order to be able to avoid creating unnecessary closures. You probably don't need this optimization unless you're pushing a *lot* of functions.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,13 @@ pTry(() => {
 ```
 
 
+## API
+
+### pTry(fn, ...args)
+
+Returns a `Promise` resolved with the value of calling `fn(...args)`. If the function throws an error, the returned `Promise` will be rejected with that error.
+
+
 ## Related
 
 - [p-finally](https://github.com/sindresorhus/p-finally) - `Promise#finally()` ponyfill - Invoked when the promise is settled regardless of outcome

--- a/test.js
+++ b/test.js
@@ -13,3 +13,7 @@ test(async t => {
 		throw fixtureErr;
 	}), fixtureErr.message);
 });
+
+test('Allows passing arguments through', async t => {
+	t.is(await m(a => a, fixture), fixture);
+});


### PR DESCRIPTION
This can be very useful when V8 cannot optimize away the cost of creating a generalized function. Example usage: https://github.com/sindresorhus/p-limit/pull/8